### PR TITLE
Fix examples for latest rust nightly

### DIFF
--- a/examples/msgsend/main.rs
+++ b/examples/msgsend/main.rs
@@ -5,6 +5,7 @@
 // I *think* it's the same, more or less.
 
 #![crate_name = "msgsend"]
+#![allow(unstable)]
 
 extern crate time;
 extern crate zmq;

--- a/examples/msgsend/main.rs
+++ b/examples/msgsend/main.rs
@@ -50,16 +50,16 @@ fn spawn_server(ctx: &mut zmq::Context, workers: uint) -> Sender<()> {
 
     Thread::spawn(move|| {
         // Let the main thread know we're ready.
-        ready_tx.send(());
+        ready_tx.send(()).unwrap();
 
         // Wait until we need to start.
-        start_rx.recv();
+        start_rx.recv().unwrap();
 
         server(pull_socket, push_socket, workers);
     });
 
     // Wait for the server to start.
-    ready_rx.recv();
+    ready_rx.recv().unwrap();
 
     start_tx
 }
@@ -83,15 +83,15 @@ fn spawn_worker(ctx: &mut zmq::Context, count: uint) -> Receiver<()> {
     let (tx, rx) = channel();
     Thread::spawn(move|| {
         // Let the main thread we're ready.
-        tx.send(());
+        tx.send(()).unwrap();
 
         worker(push_socket, count);
 
-        tx.send(());
+        tx.send(()).unwrap();
     });
 
     // Wait for the worker to start.
-    rx.recv();
+    rx.recv().unwrap();
 
     rx
 }
@@ -116,11 +116,11 @@ fn run(ctx: &mut zmq::Context, size: uint, workers: uint) {
 
     let start = time::precise_time_s();
 
-    start_ch.send(());
+    start_ch.send(()).unwrap();
 
     // Block until all the workers finish.
     for po in worker_results.iter() {
-        po.recv();
+        po.recv().unwrap();
     }
 
     // Receive the final count.

--- a/examples/msgsend/main.rs
+++ b/examples/msgsend/main.rs
@@ -13,8 +13,8 @@ use std::os;
 use std::thread::Thread;
 use std::sync::mpsc::{channel, Sender, Receiver};
 
-fn server(mut pull_socket: zmq::Socket, mut push_socket: zmq::Socket, mut workers: uint) {
-    let mut count = 0u;
+fn server(mut pull_socket: zmq::Socket, mut push_socket: zmq::Socket, mut workers: u64) {
+    let mut count = 0;
     let mut msg = zmq::Message::new().unwrap();
 
     while workers != 0 {
@@ -37,7 +37,7 @@ fn server(mut pull_socket: zmq::Socket, mut push_socket: zmq::Socket, mut worker
     }
 }
 
-fn spawn_server(ctx: &mut zmq::Context, workers: uint) -> Sender<()> {
+fn spawn_server(ctx: &mut zmq::Context, workers: u64) -> Sender<()> {
     let mut pull_socket = ctx.socket(zmq::PULL).unwrap();
     let mut push_socket = ctx.socket(zmq::PUSH).unwrap();
 
@@ -64,16 +64,16 @@ fn spawn_server(ctx: &mut zmq::Context, workers: uint) -> Sender<()> {
     start_tx
 }
 
-fn worker(mut push_socket: zmq::Socket, count: uint) {
+fn worker(mut push_socket: zmq::Socket, count: u64) {
     for _ in range(0, count) {
-        push_socket.send_str(100u.to_string().as_slice(), 0).unwrap();
+        push_socket.send_str(100.to_string().as_slice(), 0).unwrap();
     }
 
     // Let the server know we're done.
     push_socket.send_str("", 0).unwrap();
 }
 
-fn spawn_worker(ctx: &mut zmq::Context, count: uint) -> Receiver<()> {
+fn spawn_worker(ctx: &mut zmq::Context, count: u64) -> Receiver<()> {
     let mut push_socket = ctx.socket(zmq::PUSH).unwrap();
 
     push_socket.connect("inproc://server-pull").unwrap();
@@ -96,7 +96,7 @@ fn spawn_worker(ctx: &mut zmq::Context, count: uint) -> Receiver<()> {
     rx
 }
 
-fn run(ctx: &mut zmq::Context, size: uint, workers: uint) {
+fn run(ctx: &mut zmq::Context, size: u64, workers: u64) {
     let start_ch = spawn_server(ctx, workers);
 
     // Create some command/control sockets.
@@ -146,14 +146,14 @@ fn main() {
 
     let args = if os::getenv("RUST_BENCH").is_some() {
         vec!("".to_string(), "1000000".to_string(), "10000".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "10000".to_string(), "4".to_string())
     } else {
         args
     };
 
-    let size: uint = args[1].as_slice().parse().unwrap();
-    let workers: uint = args[2].as_slice().parse().unwrap();
+    let size = args[1].as_slice().parse().unwrap();
+    let workers = args[2].as_slice().parse().unwrap();
 
     let mut ctx = zmq::Context::new();
 

--- a/examples/msgsend/main.rs
+++ b/examples/msgsend/main.rs
@@ -19,9 +19,9 @@ fn server(mut pull_socket: zmq::Socket, mut push_socket: zmq::Socket, mut worker
 
     while workers != 0 {
         match pull_socket.recv(&mut msg, 0) {
-            Err(e) => panic!(e.to_string()),
+            Err(e) => panic!(e),
             Ok(()) => {
-                let s = msg.as_str().ok().unwrap();
+                let s = msg.as_str().unwrap();
                 if s.is_empty() {
                     workers -= 1;
                 } else {
@@ -33,7 +33,7 @@ fn server(mut pull_socket: zmq::Socket, mut push_socket: zmq::Socket, mut worker
 
     match push_socket.send_str(count.to_string().as_slice(), 0) {
         Ok(()) => { }
-        Err(e) => panic!(e.to_string()),
+        Err(e) => panic!(e),
     }
 }
 
@@ -126,10 +126,10 @@ fn run(ctx: &mut zmq::Context, size: uint, workers: uint) {
     // Receive the final count.
     let result: i32 = match pull_socket.recv_msg(0) {
         Ok(msg) => {
-            let msg_str: &str = msg.as_str().ok().unwrap();
+            let msg_str: &str = msg.as_str().unwrap();
             msg_str.parse().unwrap()
         },
-        Err(e) => panic!(e.to_string()),
+        Err(e) => panic!(e),
     };
 
     let end = time::precise_time_s();

--- a/examples/zguide/helloworld-client/main.rs
+++ b/examples/zguide/helloworld-client/main.rs
@@ -1,6 +1,7 @@
 //! Hello World client
 
 #![crate_name = "helloworld-client"]
+#![allow(unstable)]
 
 extern crate zmq;
 

--- a/examples/zguide/helloworld-client/main.rs
+++ b/examples/zguide/helloworld-client/main.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let mut msg = zmq::Message::new().unwrap();
 
-    for x in range(0u, 10) {
+    for x in range(0, 10) {
         println!("Sending Hello {}", x);
         requester.send(b"Hello", 0).unwrap();
 

--- a/examples/zguide/helloworld-server/main.rs
+++ b/examples/zguide/helloworld-server/main.rs
@@ -1,4 +1,5 @@
 #![crate_name = "helloworld-server"]
+#![allow(unstable)]
 
 /// Hello World server in Rust
 /// Binds REP socket to tcp://*:5555

--- a/examples/zguide/version/main.rs
+++ b/examples/zguide/version/main.rs
@@ -1,4 +1,5 @@
 #![crate_name = "version"]
+#![allow(unstable)]
 
 extern crate zmq;
 

--- a/examples/zguide/weather-client/main.rs
+++ b/examples/zguide/weather-client/main.rs
@@ -1,4 +1,5 @@
 #![crate_name = "weather-client"]
+#![allow(unstable)]
 
 /*!
  * Weather update client

--- a/examples/zguide/weather-client/main.rs
+++ b/examples/zguide/weather-client/main.rs
@@ -8,7 +8,7 @@
 
 extern crate zmq;
 
-fn atoi(s: &str) -> int {
+fn atoi(s: &str) -> i64 {
     s.parse().unwrap()
 }
 
@@ -25,9 +25,9 @@ fn main() {
 
     let mut total_temp = 0;
 
-    for _ in range(0u, 100) {
+    for _ in range(0, 100) {
         let string = subscriber.recv_string(0).unwrap().unwrap();
-        let chks: Vec<int> = string.as_slice().split(' ').map(|x| atoi(x)).collect();
+        let chks: Vec<i64> = string.as_slice().split(' ').map(|x| atoi(x)).collect();
         let (_zipcode, temperature, _relhumidity) = (chks[0], chks[1], chks[2]);
         total_temp += temperature;
     }

--- a/examples/zguide/weather-client/main.rs
+++ b/examples/zguide/weather-client/main.rs
@@ -9,7 +9,7 @@
 extern crate zmq;
 
 fn atoi(s: &str) -> int {
-    from_str(s).unwrap()
+    s.parse().unwrap()
 }
 
 fn main() {

--- a/examples/zguide/weather-server/main.rs
+++ b/examples/zguide/weather-server/main.rs
@@ -1,4 +1,5 @@
 #![crate_name = "weather-server"]
+#![allow(unstable)]
 
 /// Weather update server
 /// Binds PUB socket to tcp://*:5556 and ipc://weather.ipc

--- a/examples/zguide/weather-server/main.rs
+++ b/examples/zguide/weather-server/main.rs
@@ -18,9 +18,9 @@ fn main() {
     let mut rng = std::rand::weak_rng();
 
     loop {
-        let zipcode     = rng.gen_range(0i, 100000i);
-        let temperature = rng.gen_range(-80i, 135i);
-        let relhumidity = rng.gen_range(10i, 60i);
+        let zipcode     = rng.gen_range(0, 100000);
+        let temperature = rng.gen_range(-80, 135);
+        let relhumidity = rng.gen_range(10, 60);
 
         // this is slower than C because the current format! implementation is
         // very, very slow. Several orders of magnitude slower than glibc's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,8 @@ pub struct Socket {
     closed: bool
 }
 
+unsafe impl Send for Socket {}
+
 impl Drop for Socket {
     fn drop(&mut self) {
         match self.close_final() {


### PR DESCRIPTION
I noticed that your fork is mostly up to date for the latest nightly; but when running `cargo test` the examples failed to compile.

I've been keeping them running on my own fork so I figured I'd create a quick patch.

---

This makes one change to `src/lib.rs` which is needed for the `msgsend.rs` example: it implements `Send` for the Socket type. We have to opt-in to `Send` now because `Socket` contains types from `libc::*` (which are not marked `Send`.)

I believe this to be safe, per the ZMQ documentation:

```
Thread safety:

ØMQ sockets are not thread safe. Applications MUST NOT use a socket from multiple threads 
except after migrating a socket from one thread to another with a "full fence" memory barrier.
```

Since Rust threads are spawned w/ closures that own their environment we can reasonably conclude that the `zmq::Socket` is only accessible by one thread at a time in safe Rust.

Note that this _does not implement Sync_ meaning the Socket cannot be protected by the locking primitives in `std::sync`; which would permit multiple threads access to a single zmq::Socket. Again I believe this is in line w/ the intentions laid out by the ZMQ documentation.
