### PR TITLE
Add thread-safety markers for `zmq::Context` as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,9 @@ pub struct Context {
     ctx: *mut libc::c_void,
 }
 
+unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
+
 impl Context {
     pub fn new() -> Context {
         Context {


### PR DESCRIPTION
Whoops, sorry, I forgot to add this commit in my last PR.
It adds Send+Sync markers for zmq::Context as well.

It's not necessary for the examples; but I've found it useful in my own applications.

---

From the docs: 

```
A 0MQ context is thread safe and may be shared
among as many application threads as necessary, without any additional locking
required on the part of the caller.
```

Thus it stands to reason that the context should be accessible from
multiple Rust tasks (Sync).
