### PR TITLE
Don't double indirect pointer received from ZMQ

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,7 +690,7 @@ impl Deref for Message {
             let ptr = self.msg.unnamed_field1.as_ptr() as *mut _;
             let data = zmq_sys::zmq_msg_data(ptr);
             let len = zmq_sys::zmq_msg_size(ptr) as uint;
-            slice::from_raw_parts(mem::transmute(&data), len)
+            slice::from_raw_parts(mem::transmute(data), len)
         }
     }
 }
@@ -702,7 +702,7 @@ impl DerefMut for Message {
         unsafe {
             let data = zmq_sys::zmq_msg_data(&mut self.msg);
             let len = zmq_sys::zmq_msg_size(&mut self.msg) as uint;
-            slice::from_raw_parts_mut(mem::transmute(&data), len)
+            slice::from_raw_parts_mut(mem::transmute(data), len)
         }
     }
 }


### PR DESCRIPTION
I updated to your latest `master` and was having major issues. I was reading garbage off the socket whenever I used `#recv_msg()`.

This extra reference appears to be the trouble-maker: `zmq_msg_data` is already returning a pointer, there's no reason to stick it behind a second indirection.

`from_raw_parts` takes `*const T` whereas the old `from_raw_buf` that was replaced took `&'a *const T`, so that must be where the problem was introduced.
